### PR TITLE
remove psycopg2 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ flask-cors
 gevent==21.8.0
 json-merge-patch
 paho-mqtt
-psycopg2
 pygeometa
 pymetdecoder-wmo==0.1.14
 synop2bufr==0.7.0


### PR DESCRIPTION
Do we need psycopg2 ? Apparently not, this PR should fix https://github.com/wmo-im/wis2box/issues/883